### PR TITLE
Add lookup and caching of groups.

### DIFF
--- a/bash_fun/gitlab/README.md
+++ b/bash_fun/gitlab/README.md
@@ -118,12 +118,18 @@ The following environment variables can be defined:
   This should be absolute, (starting with a `/`), but it should not end with a `/`.
   If not defined, `/tmp/gitlab` will be used.
   If the directory does not exist, it will be created automatically when needed.
+* `GITLAB_CACHE_DEFAULT_MAX_AGE` -
+  The default max age for cached data.
+  Format is <number>[smhdw] where s -> seconds, m -> minutes, h -> hours, d -> days, w -> weeks.
+  See `man find` in the -atime section for more info.
+  Do not include a leading + or -.
+  If not defined, the default is '23h'.
 * `GITLAB_PROJECTS_MAX_AGE` -
-  The max age that the projects list can be before it's considered out-of-date.
-  Format is `<number>[smhdw]` where `s` -> seconds, `m` -> minutes, `h` -> hours, `d` -> days, `w` -> weeks.
-  See `man find` in the `-atime` section for more info.
-  Do not include a leading `+` or `-`.
-  If not defined, the default is `23h`.
+  The max age that the projects list can be before it's refreshed when needed.
+  If not set, GITLAB_CACHE_DEFAULT_MAX_AGE or its default will be used.
+* `GITLAB_GROUPS_MAX_AGE` -
+  The max age that the groups list can be before it's refreshed when needed.
+  If not set, GITLAB_CACHE_DEFAULT_MAX_AGE or its default will be used.
 
 ## Function Details
 
@@ -634,7 +640,7 @@ The following variables will be removed:
     GITLAB_USER_INFO         GITLAB_USER_ID     GITLAB_USERNAME         GITLAB_PROJECTS
     GITLAB_MRS               GITLAB_MRS_TODO    GITLAB_MRS_BY_ME        GITLAB_TODOS
     GITLAB_JOBS              GITLAB_MERGED_MRS  GITLAB_MERGED_MRS_REPO  GITLAB_MRS_SEARCH_RESULTS
-    GITLAB_MRS_DEEP_RESULTS
+    GITLAB_MRS_DEEP_RESULTS  GITLAB_GROUPS
 
 Usage: glclean [-v|--verbose] [-l|--list] [-h|--help]
 

--- a/bash_fun/gitlab/gitlab-setup.sh
+++ b/bash_fun/gitlab/gitlab-setup.sh
@@ -10,26 +10,30 @@
 #       For example, you could put   GITLAB_PRIVATE_TOKEN=123abcABC456-98ZzYy7  in your .bash_profile file
 #       so that it's set every time you open a terminal (use your own actual token of course).
 #   5) Optionally, the following environment variables can be defined.
-#       GITLAB_REPO_DIR  ----------> The directory where your GitLab repositories are to be stored.
-#                                    This should be absolute, (starting with a '/'), but it should not end with a '/'.
-#                                    If not defined, functions that look for it will require it to be provided as input.
-#       GITLAB_BASE_DIR  ----------> This variable has been deprecated in favor of GITLAB_REPO_DIR.
-#                                    Please use that variable instead.
-#       GITLAB_CONFIG_DIR  --------> The directory where you'd like to store some configuration information used in these functions.
-#                                    This should be absolute, (starting with a '/'), but it should not end with a '/'.
-#                                    If not defined, then, if HOME is defined, "$HOME/.config/gitlab" will be used.
-#                                    If HOME is not defined, then, if GITLAB_REPO_DIR is defined, "$GITLAB_REPO_DIR/.gitlab_config" will be used.
-#                                    If GITLAB_REPO_DIR is not defined either, then any functions that uses configuration information will be unavailable.
-#                                    If a config dir can be determined, but it doesn't exist yet, it will be created automatically when needed.
-#       GITLAB_TEMP_DIR  ----------> The temporary directory you'd like to use for some random file storage.
-#                                    This should be absolute, (starting with a '/'), but it should not end with a '/'.
-#                                    If not defined, "/tmp/gitlab" will be used.
-#                                    If the directory does not exist, it will be created automatically when needed.
-#       GITLAB_PROJECTS_MAX_AGE  --> The max age that the projects list can be before it's refreshed when needed.
-#                                    Format is <number>[smhdw] where s -> seconds, m -> minutes, h -> hours, d -> days, w -> weeks.
-#                                    see `man find` in the -atime section for more info.
-#                                    Do not include a leading + or -.
-#                                    If not defined, the default is '23h'.
+#       GITLAB_REPO_DIR  ---------------> The directory where your GitLab repositories are to be stored.
+#                                         This should be absolute, (starting with a '/'), but it should not end with a '/'.
+#                                         If not defined, functions that look for it will require it to be provided as input.
+#       GITLAB_BASE_DIR  ---------------> This variable has been deprecated in favor of GITLAB_REPO_DIR.
+#                                         Please use that variable instead.
+#       GITLAB_CONFIG_DIR  -------------> The directory where you'd like to store some configuration information used in these functions.
+#                                         This should be absolute, (starting with a '/'), but it should not end with a '/'.
+#                                         If not defined, then, if HOME is defined, "$HOME/.config/gitlab" will be used.
+#                                         If HOME is not defined, then, if GITLAB_REPO_DIR is defined, "$GITLAB_REPO_DIR/.gitlab_config" will be used.
+#                                         If GITLAB_REPO_DIR is not defined either, then any functions that uses configuration information will be unavailable.
+#                                         If a config dir can be determined, but it doesn't exist yet, it will be created automatically when needed.
+#       GITLAB_TEMP_DIR  ---------------> The temporary directory you'd like to use for some random file storage.
+#                                         This should be absolute, (starting with a '/'), but it should not end with a '/'.
+#                                         If not defined, "/tmp/gitlab" will be used.
+#                                         If the directory does not exist, it will be created automatically when needed.
+#       GITLAB_CACHE_DEFAULT_MAX_AGE  --> The default max age for cached data.
+#                                         Format is <number>[smhdw] where s -> seconds, m -> minutes, h -> hours, d -> days, w -> weeks.
+#                                         See `man find` in the -atime section for more info.
+#                                         Do not include a leading + or -.
+#                                         If not defined, the default is '23h'.
+#       GITLAB_PROJECTS_MAX_AGE  -------> The max age that the projects list can be before it's refreshed when needed.
+#                                         If not set, GITLAB_CACHE_DEFAULT_MAX_AGE or its default will be used.
+#       GITLAB_GROUPS_MAX_AGE  ---------> The max age that the groups list can be before it's refreshed when needed.
+#                                         If not set, GITLAB_CACHE_DEFAULT_MAX_AGE or its default will be used.
 #
 # To make these functions usable in your terminal, use the source command on this file.
 #   For example, you could put  source gitlab-setup.sh  in your .bash_profile file.
@@ -262,6 +266,20 @@ __gitlab_do_setup () {
     else
         __gitlab_if_verbose "$warn" 2 "The GITLAB_TEMP_DIR environment variable is not set. A default value will be used."
     fi
+    if [[ -n "$GITLAB_CACHE_DEFAULT_MAX_AGE" ]]; then
+        __gitlab_if_verbose "$info" 2 "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable has a value. Making sure it is okay."
+        if [[ "$GITLAB_CACHE_DEFAULT_MAX_AGE" =~ ^[+\-] ]]; then
+            problems+=( "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable [$GITLAB_CACHE_DEFAULT_MAX_AGE] must not start with a + or -." )
+            __gitlab_if_verbose "$error" 3 "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable [$GITLAB_CACHE_DEFAULT_MAX_AGE] starts with either a + or -."
+        elif [[ "$GITLAB_CACHE_DEFAULT_MAX_AGE" =~ ^([[:digit:]]+[smhdw])+$ ]]; then
+            problems+=( "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable [$GITLAB_CACHE_DEFAULT_MAX_AGE] is not in the correct format. See the -atime section in 'man find'." )
+            __gitlab_if_verbose "$error" 3 "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable [$GITLAB_CACHE_DEFAULT_MAX_AGE] is not in the correct format."
+        else
+            __gitlab_if_verbose "$ok" 3 "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable [$GITLAB_CACHE_DEFAULT_MAX_AGE] is okay."
+        fi
+    else
+        __gitlab_if_verbose "$warn" 2 "The GITLAB_CACHE_DEFAULT_MAX_AGE environment variable is not set. A default value will be used."
+    fi
     if [[ -n "$GITLAB_PROJECTS_MAX_AGE" ]]; then
         __gitlab_if_verbose "$info" 2 "The GITLAB_PROJECTS_MAX_AGE environment variable has a value. Making sure it is okay."
         if [[ "$GITLAB_PROJECTS_MAX_AGE" =~ ^[+\-] ]]; then
@@ -275,6 +293,20 @@ __gitlab_do_setup () {
         fi
     else
         __gitlab_if_verbose "$warn" 2 "The GITLAB_PROJECTS_MAX_AGE environment variable is not set. A default value will be used."
+    fi
+    if [[ -n "$GITLAB_GROUPS_MAX_AGE" ]]; then
+        __gitlab_if_verbose "$info" 2 "The GITLAB_GROUPS_MAX_AGE environment variable has a value. Making sure it is okay."
+        if [[ "$GITLAB_GROUPS_MAX_AGE" =~ ^[+\-] ]]; then
+            problems+=( "The GITLAB_GROUPS_MAX_AGE environment variable [$GITLAB_GROUPS_MAX_AGE] must not start with a + or -." )
+            __gitlab_if_verbose "$error" 3 "The GITLAB_GROUPS_MAX_AGE environment variable [$GITLAB_GROUPS_MAX_AGE] starts with either a + or -."
+        elif [[ "$GITLAB_GROUPS_MAX_AGE" =~ ^([[:digit:]]+[smhdw])+$ ]]; then
+            problems+=( "The GITLAB_GROUPS_MAX_AGE environment variable [$GITLAB_GROUPS_MAX_AGE] is not in the correct format. See the -atime section in 'man find'." )
+            __gitlab_if_verbose "$error" 3 "The GITLAB_GROUPS_MAX_AGE environment variable [$GITLAB_GROUPS_MAX_AGE] is not in the correct format."
+        else
+            __gitlab_if_verbose "$ok" 3 "The GITLAB_GROUPS_MAX_AGE environment variable [$GITLAB_GROUPS_MAX_AGE] is okay."
+        fi
+    else
+        __gitlab_if_verbose "$warn" 2 "The GITLAB_GROUPS_MAX_AGE environment variable is not set. A default value will be used."
     fi
     __gitlab_if_verbose "$info" 1 "Done checking for problems with environment variables."
 

--- a/bash_fun/gitlab/gl-core.sh
+++ b/bash_fun/gitlab/gl-core.sh
@@ -515,13 +515,26 @@ __gl_get_user_info () {
 # Look up info on all available projects. Results are stored in $GITLAB_PROJECTS.
 # Usage: __gl_get_projects <keep quiet> <verbose>
 __gl_get_projects () {
-    local keep_quiet verbose projects_url page per_page previous_count projects
+    local keep_quiet verbose projects_url projects
     keep_quiet="$1"
     verbose="$2"
     [[ -n "$keep_quiet" ]] || echo -E -n "Getting all your GitLab projects... "
     projects_url="$( __gl_url_api_projects )?order_by=id&simple=true&membership=true&archived=false&"
     projects="$( __gl_get_all_results "$projects_url" '' '' "$verbose" 'use_keyset' )"
     GITLAB_PROJECTS="$projects"
+    [[ -n "$keep_quiet" ]] || echo -E "Done."
+}
+
+# Look up info on all available groups. Results are stored in $GITLAB_GROUPS.
+# Usage: __gl_get_groups <keep quiet> <verbose>
+__gl_get_groups () {
+    local keep_quiet verbose groups_url groups
+    keep_quiet="$1"
+    verbose="$2"
+    [[ -n "$keep_quiet" ]] || echo -E -n "Getting all your GitLab groups... "
+    groups_url="$( __gl_url_api_groups )?order_by=id&"
+    groups="$( __gl_get_all_results "$groups_url" '' '' "$verbose" )"
+    GITLAB_GROUPS="$groups"
     [[ -n "$keep_quiet" ]] || echo -E "Done."
 }
 

--- a/bash_fun/gitlab/gl-core.sh
+++ b/bash_fun/gitlab/gl-core.sh
@@ -935,6 +935,17 @@ __gl_url_api_todos_mark_all_as_done () {
     echo -E -n "/mark_as_done"
 }
 
+# Usage: __gl_url_api_groups [<group id>]
+__gl_url_api_groups () {
+    local group_id
+    group_id="$1"
+    __gl_url_api_v4
+    printf '/groups'
+    if [[ -n "$group_id" ]]; then
+        printf '/%s' "$group_id"
+    fi
+}
+
 # Creates the desired url for glopen to use.
 # Usage: __gl_url_web_repo <base url> <branch> <diff_branch>
 __gl_url_web_repo () {

--- a/bash_fun/gitlab/gl-core.sh
+++ b/bash_fun/gitlab/gl-core.sh
@@ -298,18 +298,13 @@ __gl_cache_default_max_age () {
     __gl_cache_max_age "$GITLAB_CACHE_DEFAULT_MAX_AGE" 'GITLAB_CACHE_DEFAULT_MAX_AGE'
 }
 
-# Usage: if __gl_is_valid_atime "<string>"; then
-__gl_is_valid_atime () {
-    [[ "$1" =~ ^([[:digit:]]+[smhdw])+$ ]]
-}
-
 # Usage: max_age="$( __gl_cache_max_age <value> <variable name> )"
 __gl_cache_max_age () {
     local value name retval invalid_value
     value="$1"
     name="$2"
     if [[ -n "$value" ]]; then
-        if __gl_is_valid_atime "$value"; then
+        if [[ "$value" =~ ^([[:digit:]]+[smhdw])+$ ]]; then
             retval="$value"
         else
             invalid_value='YES'

--- a/bash_fun/gitlab/gl-core.sh
+++ b/bash_fun/gitlab/gl-core.sh
@@ -239,18 +239,11 @@ __gl_ensure_projects () {
 }
 
 __gl_max_age_projects () {
-    if [[ -n "$GITLAB_PROJECTS_MAX_AGE" ]]; then
-        if [[ "$GITLAB_PROJECTS_MAX_AGE" =~ ^([[:digit:]]+[smhdw])+$ ]]; then
-            echo -E -n "$GITLAB_PROJECTS_MAX_AGE"
-            return 0
-        else
-            >&2 echo "Invalid GITLAB_PROJECTS_MAX_AGE value [$GITLAB_PROJECTS_MAX_AGE]. Using default of 23h."
-        fi
-    fi
-    echo -E -n '23h'
+    __gl_cache_max_age "$GITLAB_PROJECTS_MAX_AGE" 'GITLAB_PROJECTS_MAX_AGE'
 }
 
 __gl_projects_clear_cache () {
+    local projects_file
     projects_file="$( __gl_temp_projects_filename )"
     if [[ -f "$projects_file" ]]; then
         rm "$projects_file"

--- a/bash_fun/gitlab/glclean.sh
+++ b/bash_fun/gitlab/glclean.sh
@@ -29,7 +29,8 @@ glclean () {
     local vars_to_clean vars_str usage
     vars_to_clean=("GITLAB_USER_INFO" "GITLAB_USER_ID" "GITLAB_USERNAME" "GITLAB_PROJECTS" "GITLAB_MRS"
                    "GITLAB_MRS_TODO" "GITLAB_MRS_BY_ME" "GITLAB_TODOS" "GITLAB_JOBS" "GITLAB_MERGED_MRS"
-                   "GITLAB_MERGED_MRS_REPO" "GITLAB_MRS_SEARCH_RESULTS" "GITLAB_MRS_DEEP_RESULTS")
+                   "GITLAB_MERGED_MRS_REPO" "GITLAB_MRS_SEARCH_RESULTS" "GITLAB_MRS_DEEP_RESULTS"
+                   "GITLAB_GROUPS" )
     vars_str="$( echo -E "${vars_to_clean[*]}" | sed -E 's/ /~/g; s/([^~]+~[^~]+~[^~]+~[^~]+)~/\1\\n/g;' )"
     vars_str="$( echo -e "$vars_str" | column -s '~' -t | sed 's/^/    /' )"
     usage="$( cat << EOF


### PR DESCRIPTION
### What

1. Add ability to look up groups for the user.
1. Cache the groups list similar to the projects.
1. Update README with newly available setup variables.
1. Add the new setup variables to the setup script.
1. Add the new `GITLAB_GROUPS` variable to the list of those cleaned.

### Why

1. Going to need them for some other new features.
1. Reduce the webservice calls needed in the long run.
1. Documentation is good.
1. Just trying to be helpful.
1. Keeps glclean behaving as expected.